### PR TITLE
fix: ignore non JS files based on its extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ module.exports = {
 
 - `options.ecmaVersion`
     - This is a target ECMAScript version you expect. See the avaiable versions in the [Acorn's documentation](https://github.com/acornjs/acorn/tree/master/acorn#interface). The default version is `5`(ES5).
+- `options.test`
+    - A `RegExp` pattern to apply this plugin. The default value is `/\.(m)?js$/`.
 
 ## LICENCE
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import { ECMAVersionValidatorPlugin } from "../";
+
+describe("ECMAVersionValidatorPlugin", () => {
+  const ecmaVersion = 2020;
+  const test = /\.js/;
+  it("should set values passed with constructor", () => {
+    const plugin = new ECMAVersionValidatorPlugin({ ecmaVersion, test });
+    expect(plugin.ecmaVersion).toBe(ecmaVersion);
+    expect(plugin.test).toBe(test);
+    expect(plugin.name).toBe("ECMAVersionValidator");
+  });
+  it("should set default values if you don't pass options to the constructor", () => {
+    const plugin = new ECMAVersionValidatorPlugin();
+    expect(plugin.ecmaVersion).toBe(5);
+    expect(plugin.test.toString()).toBe(/\.(m)?js$/.toString());
+  });
+  it("should set default values if you don't pass ecmaVersion", () => {
+    const plugin = new ECMAVersionValidatorPlugin({ test });
+    expect(plugin.ecmaVersion).toBe(5);
+    expect(plugin.test).toBe(test);
+  });
+  it("should set default values if you don't pass test value", () => {
+    const plugin = new ECMAVersionValidatorPlugin({ ecmaVersion });
+    expect(plugin.ecmaVersion).toBe(ecmaVersion);
+    expect(plugin.test.toString()).toBe(/\.(m)?js$/.toString());
+  });
+});

--- a/src/__tests__/validate.test.ts
+++ b/src/__tests__/validate.test.ts
@@ -10,7 +10,7 @@ describe("validate", () => {
             "foo.js": new RawSource("console.log(123);"),
             "bar.js": new RawSource("var bar = 123"),
           },
-          { ecmaVersion: 5 }
+          { ecmaVersion: 5, test: /\.js/ }
         );
       }).not.toThrow();
     });
@@ -21,7 +21,7 @@ describe("validate", () => {
             "foo.js": new RawSource("const foo = () => console.log(123);"),
             "bar.js": new RawSource("class Bar {}"),
           },
-          { ecmaVersion: 2015 }
+          { ecmaVersion: 2015, test: /\.js/ }
         );
       }).not.toThrow();
     });
@@ -33,7 +33,18 @@ describe("validate", () => {
               new RawSource("function foo() { console.log(123); }")
             ),
           },
-          { ecmaVersion: 5 }
+          { ecmaVersion: 5, test: /\.js/ }
+        );
+      }).not.toThrow();
+    });
+    it("should ignore non JS files", () => {
+      expect(() => {
+        validate(
+          {
+            "foo.js": new RawSource("function foo() { console.log(123); }"),
+            "bar.css": new RawSource(".bar { font-size: 1rem; }"),
+          },
+          { ecmaVersion: 5, test: /\.js/ }
         );
       }).not.toThrow();
     });
@@ -49,7 +60,7 @@ describe("validate", () => {
             "bar.js": new RawSource("var bar = 1;\nclass Bar {}"),
             "baz.js": new RawSource("var baz = true"),
           },
-          { ecmaVersion: 5 }
+          { ecmaVersion: 5, test: /\.js/ }
         );
       }).toThrowErrorMatchingSnapshot();
     });
@@ -61,7 +72,7 @@ describe("validate", () => {
               new RawSource("var foo = 1;\nvar foo = () => console.log(123);")
             ),
           },
-          { ecmaVersion: 5 }
+          { ecmaVersion: 5, test: /\.js/ }
         );
       }).toThrowErrorMatchingSnapshot();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,19 @@ import { validate, ECMAVersion } from "./validate";
 export class ECMAVersionValidatorPlugin implements Plugin {
   name: string;
   ecmaVersion: ECMAVersion;
-  constructor(options: { ecmaVersion: ECMAVersion } = { ecmaVersion: 5 }) {
+  test: RegExp;
+  constructor(options: { ecmaVersion?: ECMAVersion; test?: RegExp } = {}) {
+    const { ecmaVersion, test } = options;
     this.name = "ECMAVersionValidator";
-    this.ecmaVersion = options.ecmaVersion;
+    this.ecmaVersion = ecmaVersion ?? 5;
+    this.test = test || /\.(m)?js$/;
   }
   apply(compiler: Compiler) {
     compiler.hooks.emit.tap(this.name, (compilation) => {
-      validate(compilation.assets, { ecmaVersion: this.ecmaVersion });
+      validate(compilation.assets, {
+        ecmaVersion: this.ecmaVersion,
+        test: this.test,
+      });
     });
   }
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -18,22 +18,24 @@ export type ErrorMap = Map<
 
 export const validate = (
   assets: { [file: string]: Source },
-  options: { ecmaVersion: ECMAVersion }
+  options: { ecmaVersion: ECMAVersion; test: RegExp }
 ) => {
-  const { ecmaVersion } = options;
+  const { ecmaVersion, test } = options;
   const errors: ErrorMap = new Map();
-  Object.entries(assets).forEach(([file, source]) => {
-    const sourceCode = source.source();
-    try {
-      parse(sourceCode, { ecmaVersion });
-    } catch (e) {
-      errors.set(file, {
-        message: e.message,
-        source: sourceCode,
-        position: e.loc,
-      });
-    }
-  });
+  Object.entries(assets)
+    .filter(([file]) => test.test(file))
+    .forEach(([file, source]) => {
+      const sourceCode = source.source();
+      try {
+        parse(sourceCode, { ecmaVersion });
+      } catch (e) {
+        errors.set(file, {
+          message: e.message,
+          source: sourceCode,
+          position: e.loc,
+        });
+      }
+    });
   if (errors.size > 0) {
     throw new Error(format(errors));
   }


### PR DESCRIPTION
Currently, if there are any non-JS source files, the plugin fails.
To fix this, I've added an option called `test` to pass `RegExp` to determine which files should be applied.